### PR TITLE
[BUGFIX]: fix issues with progress bar seek

### DIFF
--- a/assets/js/hooks/progress_bar.js
+++ b/assets/js/hooks/progress_bar.js
@@ -6,7 +6,10 @@ import {seekTimeBridge, heartbeatBridge} from "./media_bridge.js"
 
 ProgressBar = {
   mounted() {
-    this.el.addEventListener("click", (e) => this.handleProgressBarClick(e));
+    this.el.addEventListener("click", (e) => {
+      e.preventDefault();
+      this.handleProgressBarClick(e)
+    });
 
     const heartbeatDeregisterer = heartbeatBridge.sub(payload => this.handleHeartbeat(payload))
     const seekTimeDeregisterer = seekTimeBridge.sub(payload => this.handleExternalSeekTime(payload))

--- a/lib/vyasa_web/live/media_live/media_bridge.ex
+++ b/lib/vyasa_web/live/media_live/media_bridge.ex
@@ -69,7 +69,7 @@ defmodule VyasaWeb.MediaLive.MediaBridge do
     now = DateTime.utc_now()
     played_at = cond do
       elapsed > 0 -> # resume case
-        DateTime.add(now, -elapsed, :millisecond)
+        DateTime.add(now, -round(elapsed), :millisecond)
       elapsed == 0 -> # fresh start case
         now
       true ->
@@ -329,6 +329,7 @@ end
     <div
       id={"#{@id}-container"}
       class="bg-gray-200 flex-auto dark:bg-black rounded-full overflow-hidden"
+      phx-update="ignore"
       phx-hook="ProgressBar"
       data-value={@value}
       data-max={@max}


### PR DESCRIPTION
Key Learnings:
1. crash was happening because of a known case encountered before: remember to use integers for DateTime.add()

2. As for the dom issues, using the browser's debugger showed that when using a watch expression for the style state, it would go out of scope (implying a re-render). Hence the realisation that it's a matter of ignoring the dom-patching by LiveView. Based on the documentation for it [^1], it seems that ignoring dom-patching should be considered whenever we use JS-hooks to programmatically manipulate the state.

[^1]: https://hexdocs.pm/phoenix_live_view/dom-patching.html