### PR TITLE
ReWrite how marks get initialised @ :show_verse

### DIFF
--- a/lib/vyasa/sangh/mark.ex
+++ b/lib/vyasa/sangh/mark.ex
@@ -62,13 +62,13 @@ defmodule Vyasa.Sangh.Mark do
 
   def get_next_order(marks) when is_list(marks) do
     1 +
-      ((marks
+      (marks
        |> Enum.map(& &1.order)
-       |> Enum.max(&>=/2, fn -> 0 end)) || 0)
+       |> Enum.max(&>=/2, fn -> 0 end) || 0)
   end
 
   def get_next_order(_) do
-    1
+    0
   end
 
   @doc """
@@ -91,21 +91,30 @@ defmodule Vyasa.Sangh.Mark do
   returns the same list but updates the marks with order values that are
   part of a contiguous sequence of integers.
 
+  NOTE:
   This does NOT update the timestamps of the entry since this is purely intended
   to make the data-side prettier.
 
+  Precondition:
+  * the original list of marks is ordered in descending order for the order field in marks
+  and it will return marks in the same order
+
+  Postcondition:
+  * the order of marks returned is the same as the input (descending order for the Mark.order attribute)
+
   for example:
   IN:
-  orders = [1,4,6,7]
+  orders = [7,6,4,1]
 
   OUT:
-  order = [1,2,3,4]
+  order = [4,3,2,1]
   """
   def defrag_marks_orders([%Mark{} | _] = marks) do
     marks
     |> Enum.sort_by(& &1.order)
     |> Enum.with_index(0)
     |> Enum.map(fn {mark, index} -> %Mark{mark | order: index} end)
+    |> Enum.sort_by(& &1.order, :desc)
   end
 
   def defrag_marks_orders(marks) do

--- a/lib/vyasa_web/components/contexts/components.ex
+++ b/lib/vyasa_web/components/contexts/components.ex
@@ -82,6 +82,12 @@ defmodule VyasaWeb.Context.Components do
   def mark_display(assigns) do
     ~H"""
     <div class="border-l border-brand-light pl-2">
+      <.debug_dump
+        mark_state={@mark.state}
+        mark_id={@mark.id}
+        class="relative"
+        mark_order={@mark.order}
+      />
       <%= if @mark.state == :live do %>
         <.form
           for={%{}}

--- a/lib/vyasa_web/components/contexts/read.ex
+++ b/lib/vyasa_web/components/contexts/read.ex
@@ -137,11 +137,10 @@ defmodule VyasaWeb.Context.Read do
 
       socket
       |> assign(:content_action, :show_verses)
-      |> sync_media_session()
       |> init_marks(:show_verses)
+      |> sync_media_session()
       |> assign(
         :kv_verses,
-        # creates a map of verse_id_to_verses
         Enum.into(verses, %{}, &{&1.id, &1})
       )
       |> maybe_stream_configure(:verses, dom_id: &"verse-#{&1.id}")
@@ -712,7 +711,11 @@ defmodule VyasaWeb.Context.Read do
 
   def init_marks(%Socket{} = socket, _) do
     IO.puts("INIT_MARKS POKEMON")
+    marks = [Mark.get_draft_mark()]
+
     socket
+    |> assign(marks: marks)
+    |> assign(marks_ui: marks |> MarksUiState.get_initial_ui_state())
   end
 
   defp cascade_stream_change(


### PR DESCRIPTION
I'm just going to re-write this and document the preconditions a bit better. This will hopefully solve the weird id bug that I've been getting, which has actually blocked me.

> Init Reflector

- currently marks only init for action = :show<sub>verses</sub>, this will be available for all actions once we can create bindings out of anything (including source and chapter related fields), so same pattern to use
- no ordering changes to marks, most recent gets placed at the front of things.

> Other Bugs yet to be solved

1.  There seems to be a possible bug in sessions. Replication Steps:
    1.  goto explore/ ==\> see the 3 sources loaded correctly
    2.  now click on a source (e.g. hanuman chalisa) ==\> first chapter of hanuman chalisa will load without error or issue
    3.  now refresh

    Expectation:
    1.  loads as before

    Current Observation:
    1.  crashes because of missing `@marks`. On investigation, it's becuase the sangh session is not being loaded @ mount (?) Ref dump below + fact that the IO.puts("INIT<sub>MARKS</sub>") shows up

        ``` log key :marks not found in: %{ id: "read", meta: %{ type: "website", description: "The Hanuman Chalisa, composed by Goswami Tulsidas, is a  40-verse hymn dedicated to Lord Hanuman, highlighting his unwavering devotion to Lord Rama. It is a testament to Hanuman's strength, wisdom, and courage, as well as his role in Lord Rama's epic battles against evil. Reciting this hymn is believed to bestow blessings and protection from Hanuman, fostering spiritual growth and devotion to Lord Rama.", title: "Hanuman Chalisa Chapter 1 | Hanuman Chalisa", image: "http://localhost:4000/og/source_hanuman_chalisa_1.png", url: "http://localhost:4000/explore/hanuman_chalisa/1" }, socket: #Phoenix.LiveView.Socket< id: "phx-F_3zVu0qx9P6GUUD", endpoint: VyasaWeb.Endpoint, view: VyasaWeb.ModeLive.Mediator, parent_pid: nil, root_pid: nil, router: VyasaWeb.Router, assigns: #Phoenix.LiveView.Socket.AssignsNotInSocket<>, transport_pid: nil, ...
          >,
          session: %VyasaWeb.Session{
            name: nil,
            id: nil,
            active: true,
            sangh: nil,
            last_opened: ~U[2024-09-23 13:49:57.741411Z]
          },
        ```

> Preconditions / Invariants to follow

1.  following our pre-load order, the order of marks will always be in descending order of order field. No state held anywhere that we expect to READ and WRITE on should be doing any order changes. This would mean that the Enum.reverse() only happen @ last-possible point where it's read (e.g. function component that does display of marks)