### PR TITLE
Discuss: init drafting and reply_to contexts

### DIFF
--- a/README.org
+++ b/README.org
@@ -6,7 +6,6 @@ Wherever there be anything you dost not comprehend, cease to continue writing
 -- Vyasa, Adi Parva - Mahabharatam
 #+END_QUOTE
 
-
 *  What is the _*Vyasa Project*_?
 =TODO=
 

--- a/lib/vyasa_web/components/contexts/discuss.ex
+++ b/lib/vyasa_web/components/contexts/discuss.ex
@@ -4,11 +4,13 @@ defmodule VyasaWeb.Context.Discuss do
   """
   use VyasaWeb, :live_component
 
+  alias EctoLtree.LabelTree, as: Ltree
   alias VyasaWeb.ModeLive.{UserMode}
   alias VyasaWeb.Session
   alias Phoenix.LiveView.Socket
   alias Vyasa.Sangh.Session, as: SanghSession
-  alias Vyasa.Sangh.{SheafLattice, Sheaf}
+  alias Vyasa.Sangh
+  alias Vyasa.Sangh.{SheafLattice, Sheaf, Mark}
   alias VyasaWeb.Context.Components.UiState.Sheaf, as: SheafUiState
   import VyasaWeb.Context.Discuss.SheafTree
   import VyasaWeb.Context.Components
@@ -56,6 +58,8 @@ defmodule VyasaWeb.Context.Discuss do
     |> assign(content_action: :index)
     |> init_sheaf_lattice()
     |> init_sheaf_ui_lattice()
+    |> init_drafting_context()
+    |> init_reply_to_context()
   end
 
   # when there is no sangh session in state:
@@ -70,6 +74,56 @@ defmodule VyasaWeb.Context.Discuss do
     |> assign(content_action: :index)
     |> init_sheaf_lattice()
     |> init_sheaf_ui_lattice()
+  end
+
+  @doc """
+  Adds a new sheaf to both the sheaf_lattice and sheaf_ui_lattice.
+  This is destructive, and will do overwrites if an existing sheaf exists.
+  Note that this and anything downstream of this function will not do any db writes,
+  will only update the lattices kept in socket state.
+  """
+  def register_sheaf(
+        %Socket{
+          assigns: %{
+            sheaf_lattice: %{} = sheaf_lattice,
+            sheaf_ui_lattice: %{} = sheaf_ui_lattice
+          }
+        } = socket,
+        %Sheaf{} = new_sheaf
+      ) do
+    socket
+    |> assign(
+      sheaf_lattice:
+        sheaf_lattice
+        |> SheafLattice.insert_sheaf_into_lattice(new_sheaf)
+    )
+    |> assign(
+      sheaf_ui_lattice:
+        sheaf_ui_lattice
+        |> SheafLattice.insert_sheaf_into_ui_lattice(new_sheaf)
+    )
+  end
+
+  def deregister_sheaf(
+        %Socket{
+          assigns: %{
+            sheaf_lattice: %{} = sheaf_lattice,
+            sheaf_ui_lattice: %{} = sheaf_ui_lattice
+          }
+        } = socket,
+        %Sheaf{} = old_sheaf
+      ) do
+    socket
+    |> assign(
+      sheaf_lattice:
+        sheaf_lattice
+        |> SheafLattice.remove_sheaf_from_lattice(old_sheaf)
+    )
+    |> assign(
+      sheaf_ui_lattice:
+        sheaf_ui_lattice
+        |> SheafLattice.remove_sheaf_from_ui_lattice(old_sheaf)
+    )
   end
 
   defp init_sheaf_lattice(
@@ -122,10 +176,202 @@ defmodule VyasaWeb.Context.Discuss do
     |> assign(sheaf_ui_lattice: nil)
   end
 
+  @doc """
+  Defines the drafting context by setting the draft_reflector_path and updating
+  the respective state and ui_state lattices.
+
+  Additionally, ensures that there's at least one draft mark in the marks that draft reflector
+  keeps in state.
+
+  There are no db writes that will be done in this function and anything downstream of it.
+  """
+  def init_drafting_context(
+        %Socket{
+          assigns: %{
+            session: %{sangh: %{id: _sangh_id}}
+          }
+        } = socket
+      ) do
+    socket
+    |> init_draft_reflector()
+    |> maybe_prepend_draft_mark_in_reflector()
+  end
+
+  # fallthrough
+  def init_drafting_context(%Socket{} = socket) do
+    socket
+    |> assign(draft_reflector_path: nil)
+  end
+
+  @doc """
+  Similar to the read mode, this function defines what the currently in-draft sheaf is for:
+  case 1: when there's a parent sheaf to it, it means that this draft sheaf, if published, will respond to that parent.
+  case 2: when there's no parent sheaf to it, then it means that the draft sheaf, if published, will be a root sheaf.
+
+  TODO: similar to the read::init_reply_to_context, url overrides may happen.
+  """
+  def init_reply_to_context(
+        %Socket{
+          assigns: %{
+            session: %{sangh: %{id: _sangh_id}},
+            draft_reflector_path: %Ltree{labels: lattice_key} = _reflector_path,
+            sheaf_lattice: %{} = sheaf_lattice,
+            sheaf_ui_lattice: %{}
+          }
+        } = socket
+      ) do
+    %Sheaf{
+      parent_id: parent_id
+    } = _reflected_sheaf = sheaf_lattice |> Map.get(lattice_key)
+
+    reply_to_path =
+      case parent_id do
+        p_id when is_binary(p_id) ->
+          # case 1: there's a parent sheaf that is being responded to
+          %Sheaf{
+            id: ^p_id,
+            path: %Ltree{} = parent_path
+          } = _parent = Sangh.get_sheaf(p_id)
+
+          parent_path
+
+        _ ->
+          # case 2: publishing this draft sheaf will end up creating a root sheaf
+          nil
+      end
+
+    socket
+    |> assign(reply_to_path: reply_to_path)
+  end
+
+  # fallthrough
+  def init_reply_to_context(%Socket{} = socket) do
+    socket
+    |> assign(reply_to_path: nil)
+  end
+
+  @doc """
+  Only initialises a draft reflector in the socket state. If there's no existing
+  draft reflector(s) in the db, then we shall create a new draft sheaf.
+
+  Since we are keeping state within the lattices, we shall only add reflector's path to socket state,
+  since it can be used to get access the sheaf latttices and and update lattices accordingly by using register_sheaf()
+  """
+  def init_draft_reflector(
+        %Socket{
+          assigns: %{
+            session: %{sangh: %{id: sangh_id}},
+            sheaf_lattice: %{},
+            sheaf_ui_lattice: %{}
+          }
+        } = socket
+      ) do
+    draft_sheafs = sangh_id |> Vyasa.Sangh.get_sheafs_by_session(%{traits: ["draft"]})
+
+    case draft_sheafs do
+      [%Sheaf{path: %Ltree{} = path} = draft_sheaf | _] ->
+        socket
+        |> assign(draft_reflector_path: path)
+        # possibly redundant, registering here for extra measure:
+        |> register_sheaf(draft_sheaf)
+
+      _ ->
+        %Sheaf{path: %Ltree{} = path} = new_draft_sheaf = Sheaf.draft!(sangh_id)
+
+        socket
+        |> assign(draft_reflector_path: path)
+        |> register_sheaf(new_draft_sheaf)
+    end
+  end
+
+  @doc """
+  Ensures that the current draft reflector will always have a draft mark at the head of
+  its list of marks.
+
+  If there's a need to, a new draft mark will be prepended and we will register the sheaf
+  again, which will just overwrite existing state in the various lattices.
+  """
+  def maybe_prepend_draft_mark_in_reflector(
+        %Socket{
+          assigns: %{
+            session: %{sangh: %{id: _sangh_id}},
+            draft_reflector_path:
+              %Ltree{
+                labels: lattice_key
+              } = _path,
+            sheaf_lattice: %{} = sheaf_lattice,
+            sheaf_ui_lattice: %{}
+          }
+        } = socket
+      ) do
+    possible_new_draft = Mark.get_draft_mark()
+
+    %Sheaf{
+      marks: marks
+    } = reflected_sheaf = sheaf_lattice |> Map.get(lattice_key)
+
+    case marks do
+      # case 1: has existing draft marks, no change needed
+      [%Mark{state: :draft} | _] = _existing_marks ->
+        socket
+
+      # case 2: has existing marks that are non-draft, but 0 draft marks:
+      [%Mark{} | _] = existing_marks ->
+        updated_reflector = %Sheaf{reflected_sheaf | marks: [possible_new_draft | existing_marks]}
+
+        socket
+        |> register_sheaf(updated_reflector)
+
+      # case 3 no existing marks:
+      _ ->
+        updated_reflector = %Sheaf{reflected_sheaf | marks: [possible_new_draft]}
+
+        socket
+        |> register_sheaf(updated_reflector)
+    end
+  end
+
+  # @doc """
+  # Inserts a particular mark into a particular sheaf in the lattice.
+
+  # Intent is that it gets used when creating a mark in the discuss mode.
+  # TODO: figure out what is the best place to put this? likely when creating mark
+  # """
+  # def insert_mark_into_sheaf_in_lattice(
+  #       %{} = lattice,
+  #       %Ltree{labels: lattice_key} = _sheaf_path,
+  #       %Mark{id: mark_id, body: body} = mark
+  #     ) do
+  #   %Sheaf{
+  #     marks: rest_marks
+  #   } = target_sheaf = lattice |> Map.get(lattice_key)
+
+  #   updated_new_mark = %Mark{
+  #     mark
+  #     | id: if(not is_nil(mark_id), do: Ecto.UUID.generate(), else: mark_id),
+  #       order: Mark.get_next_order(rest_marks),
+  #       body: body,
+  #       state: :live
+  #   }
+
+  #   updated_sheaf = %Sheaf{target_sheaf | marks: [updated_new_mark | rest_marks]}
+
+  #   socket
+  #   |> register_sheaf(updated_sheaf)
+  # end
+
   @impl true
   def render(assigns) do
     ~H"""
     <div id={@id}>
+      <.debug_dump
+        :if={Map.has_key?(assigns, :draft_reflector_path)}
+        label="Context Dump on Discussions"
+        draft_reflector_path={@draft_reflector_path}
+        reply_to_path={@reply_to_path}
+        reflected={@sheaf_lattice |> Map.get(@draft_reflector_path.labels)}
+        reflected_ui={@sheaf_ui_lattice |> Map.get(@draft_reflector_path.labels)}
+      />
       <div id="content-display" class="mx-auto max-w-2xl pb-16">
         <%= if not is_nil(@sheaf_lattice) do %>
           <div :for={

--- a/lib/vyasa_web/components/contexts/read.ex
+++ b/lib/vyasa_web/components/contexts/read.ex
@@ -226,21 +226,10 @@ defmodule VyasaWeb.Context.Read do
             }
           }
         } = socket
-      ) do
-    reply_to_sheaf =
-      case parent_id do
-        p_id when is_binary(p_id) ->
-          Sangh.get_sheaf(p_id)
-
-        p when is_nil(p) ->
-          nil
-
-        _ ->
-          nil
-      end
-
+      )
+      when is_binary(parent_id) do
     socket
-    |> assign(reply_to: reply_to_sheaf)
+    |> assign(reply_to: Sangh.get_sheaf(parent_id))
   end
 
   def init_reply_to_context(%Socket{} = socket) do

--- a/lib/vyasa_web/live/mode_live/user_mode.ex
+++ b/lib/vyasa_web/live/mode_live/user_mode.ex
@@ -74,8 +74,8 @@ defmodule VyasaWeb.ModeLive.UserMode do
   def supported_modes, do: Map.keys(@defs)
 
   def get_initial_mode() do
-    "read"
-    # "discuss"
+    # "read"
+    "discuss"
     |> get_mode()
   end
 


### PR DESCRIPTION
1 Init Drafting and Reply To Contexts
═════════════════════════════════════

  now that we have the read context cleaned up for both data and ui
  being managed at the sheaf-level, we just have to do the same for
  discuss, interfaced via the lattice.

1.1 Notes
─────────

  1. At the same time we need to provision contexts:

     ‣ Reply to context: what is the current intent that you’re replying
       to
     ‣ drafting context: what are we currently drafting marks for?
     the lattices shall be the source of truth: -> sheaf_lattice: for
     data on sheafs, including marks -> sheaf_ui_lattice: for data on ui
     states

     We shall keep the lattices as the source of truth, so the
     `reply_to' and `draft_reflector' will be keeping the state, and the
     variables in state will just be the paths that point to the state,
     or in this case, the labels.

     Since state will be within the lattices, we don’t need a
     `draft_reflector_ui_id'

  2. There’s actually a bit of duplicated patterns in both read and
     discuss modes, but I shall continue with the duplication until the
     patterns are well defined and ready to be refactored. I think the
     way to know if it’s time to refactor something is if the
     refactoring is going to be an easy task.