### PR TITLE
Add mode-specific routes, inject mode @ mediator

### DIFF
--- a/lib/vyasa_web/components/contexts/discuss.ex
+++ b/lib/vyasa_web/components/contexts/discuss.ex
@@ -27,7 +27,7 @@ defmodule VyasaWeb.Context.Discuss do
           params,
         socket
       ) do
-    IO.inspect(params, label: "TRACE: params passed to ReadContext")
+    IO.inspect(params, label: "TRACE: params passed to Discuss")
 
     {
       :ok,

--- a/lib/vyasa_web/components/contexts/read.ex
+++ b/lib/vyasa_web/components/contexts/read.ex
@@ -67,20 +67,21 @@ defmodule VyasaWeb.Context.Read do
     {:ok, socket}
   end
 
-  #received changes to binding
+  # received changes to binding
 
   def update(
-    %{id: "read", binding: bind = %{verse_id: verse_id}},
-    %{
-      assigns: %{
-        kv_verses: verses,
-        draft_reflector:
-        %Sheaf{
-          marks: [%Mark{state: :draft, verse_id: curr_verse_id} = d_mark | marks]
-        } = draft_reflector
-      }
-    } = socket
-  ) when is_binary(curr_verse_id) and verse_id != curr_verse_id do
+        %{id: "read", binding: bind = %{verse_id: verse_id}},
+        %{
+          assigns: %{
+            kv_verses: verses,
+            draft_reflector:
+              %Sheaf{
+                marks: [%Mark{state: :draft, verse_id: curr_verse_id} = d_mark | marks]
+              } = draft_reflector
+          }
+        } = socket
+      )
+      when is_binary(curr_verse_id) and verse_id != curr_verse_id do
     # binding here blocks the stream from appending to quote
     #
     bound_verses =
@@ -99,7 +100,7 @@ defmodule VyasaWeb.Context.Read do
 
   # already in mark in drafting state, remember to late bind binding => with a fn()
   def update(
-    %{id: "read", binding: bind = %{verse_id: verse_id}},
+        %{id: "read", binding: bind = %{verse_id: verse_id}},
         %{
           assigns: %{
             kv_verses: verses,
@@ -110,7 +111,6 @@ defmodule VyasaWeb.Context.Read do
           }
         } = socket
       ) do
-
     # binding here blocks the stream from appending to quote
     bound_verses = put_in(verses[verse_id].binding, bind)
     updated_draft_mark = d_mark |> Mark.update_mark(%{binding: bind, verse_id: verse_id})
@@ -119,14 +119,13 @@ defmodule VyasaWeb.Context.Read do
      socket
      |> mutate_verses(verse_id, bound_verses)
      |> assign(draft_reflector: %Sheaf{draft_reflector | marks: [updated_draft_mark | marks]})
-     |> push_event("bind::jump", bind)
-    }
+     |> push_event("bind::jump", bind)}
   end
 
-
   ## this is a dead clause to catch error states with draft_reflector to ensure the initial draft mark
-  def update(%{id: "read", binding: bind = %{verse_id: verse_id}},
-    %{
+  def update(
+        %{id: "read", binding: bind = %{verse_id: verse_id}},
+        %{
           assigns: %{
             kv_verses: verses,
             draft_reflector:
@@ -136,7 +135,6 @@ defmodule VyasaWeb.Context.Read do
           }
         } = socket
       ) do
-
     bound_verses = put_in(verses[verse_id].binding, bind)
 
     new_marks = [
@@ -150,10 +148,8 @@ defmodule VyasaWeb.Context.Read do
      |> assign(draft_reflector: %Sheaf{draft_reflector | marks: new_marks})}
   end
 
-
   @impl true
   def update(_assigns, socket) do
-
     {:ok, socket}
   end
 
@@ -164,11 +160,11 @@ defmodule VyasaWeb.Context.Read do
       content_action: :show_sources,
       page_title: "Sources",
       meta: %{
-        title: "Sources to Explore",
-        description: "Explore the wealth of indic knowledge, distilled into words.",
+        title: "Sources to Read",
+        description: "Read the wealth of indic knowledge, distilled into words.",
         type: "website",
         image: url(~p"/images/the_vyasa_project_1.png"),
-        url: url(socket, ~p"/explore/")
+        url: url(socket, ~p"/read/")
       }
     })
   end
@@ -189,10 +185,10 @@ defmodule VyasaWeb.Context.Read do
         source: source,
         meta: %{
           title: to_title_case(source.title),
-          description: "Explore the #{to_title_case(source.title)}",
+          description: "Read the #{to_title_case(source.title)}",
           type: "website",
           image: url(~p"/og/#{VyasaWeb.OgImageController.get_by_binding(%{source: source})}"),
-          url: url(socket, ~p"/explore/#{source.title}")
+          url: url(socket, ~p"/read/#{source.title}")
         }
       })
       |> Stream.maybe_stream_configure(:chapters, dom_id: &"Chapter-#{&1.no}")
@@ -236,7 +232,7 @@ defmodule VyasaWeb.Context.Read do
           type: "website",
           image:
             url(~p"/og/#{OgImageController.get_by_binding(%{chapter: chap, source: source})}"),
-          url: url(socket, ~p"/explore/#{source.title}/#{chap_no}")
+          url: url(socket, ~p"/read/#{source.title}/#{chap_no}")
         }
       })
       |> init_drafting_context()
@@ -294,7 +290,7 @@ defmodule VyasaWeb.Context.Read do
       1B: non-nil then load that parent sheaf as reply_to
   2) TODO  @ks0m1c via url params, as permalinked ==> this will take precendence over the db-based determining of reply_to_context
      --- /http://localhost:4000/<mode>/<binding_type>/id=xxx
-     --- /http://localhost:4000/explore/<slug for chapter>/id=xxx
+     --- /http://localhost:4000/read/<slug for chapter>/id=xxx
      --- /http://localhost:4000/discuss/sheaf/id=xxx
          ==> discuss mode shows the threads
      --- /http://localhost:4000/read/sheaf/id=xxx
@@ -364,12 +360,10 @@ defmodule VyasaWeb.Context.Read do
 
   # fallthrough
   def init_drafting_context(%Socket{} = socket) do
-
     socket
     |> assign(draft_reflector: %Sheaf{marks: [Mark.get_draft_mark()]})
     |> assign(draft_reflector_ui: nil)
   end
-
 
   @doc """
   Only initialises a draft reflector in the socket state. If there's no existing
@@ -612,7 +606,6 @@ defmodule VyasaWeb.Context.Read do
     Vyasa.PubSub.publish(%{verse_id: verse_id}, :playback_sync, "media:session:" <> sess_id)
     {:noreply, socket}
   end
-
 
   @impl true
   def handle_event(

--- a/lib/vyasa_web/components/contexts/read/chapters.ex
+++ b/lib/vyasa_web/components/contexts/read/chapters.ex
@@ -20,7 +20,7 @@ defmodule VyasaWeb.Context.Read.Chapters do
         </div>
       </.header>
 
-      <.back patch={~p"/explore/"}>Back to All Sources</.back>
+      <.back patch={~p"/read/"}>Back to All Sources</.back>
 
       <.table
         id="chapters"
@@ -28,7 +28,7 @@ defmodule VyasaWeb.Context.Read.Chapters do
         row_click={
           fn {_id, chap} ->
             JS.push("navigate_to_chapter",
-              value: %{target: ~p"/explore/#{@source.title}/#{chap.no}/"},
+              value: %{target: ~p"/read/#{@source.title}/#{chap.no}/"},
               target: @myself
             )
           end
@@ -49,7 +49,7 @@ defmodule VyasaWeb.Context.Read.Chapters do
         </:col>
       </.table>
 
-      <.back patch={~p"/explore/"}>Back to All Sources</.back>
+      <.back patch={~p"/read/"}>Back to All Sources</.back>
 
       <span :if={@chapters |> Enum.count() < 10} class="block h-96" />
     </div>

--- a/lib/vyasa_web/components/contexts/read/sources.ex
+++ b/lib/vyasa_web/components/contexts/read/sources.ex
@@ -20,7 +20,7 @@ defmodule VyasaWeb.Context.Read.Sources do
         row_click={
           fn {_id, source} ->
             JS.push("navigate_to_source",
-              value: %{target: ~p"/explore/#{source.title}/"},
+              value: %{target: ~p"/read/#{source.title}/"},
               target: @myself
             )
           end

--- a/lib/vyasa_web/components/contexts/read/verses.ex
+++ b/lib/vyasa_web/components/contexts/read/verses.ex
@@ -33,7 +33,7 @@ defmodule VyasaWeb.Context.Read.Verses do
             </div>
           </:subtitle>
         </.header>
-        <.back patch={~p"/explore/#{@src.title}"}>
+        <.back patch={~p"/read/#{@src.title}"}>
           Back to <%= to_title_case(@src.title) %> Chapters
         </.back>
         <div
@@ -62,7 +62,7 @@ defmodule VyasaWeb.Context.Read.Verses do
             ]}
           />
         </div>
-        <.back patch={~p"/explore/#{@src.title}"}>
+        <.back patch={~p"/read/#{@src.title}"}>
           Back to <%= to_title_case(@src.title) %> Chapters
         </.back>
       </div>

--- a/lib/vyasa_web/controllers/page_html/home.html.heex
+++ b/lib/vyasa_web/controllers/page_html/home.html.heex
@@ -348,7 +348,7 @@
       <div class="w-full sm:w-auto">
         <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-4 sm:grid-cols-3">
           <.link
-            navigate={~p"/explore"}
+            navigate={~p"/read"}
             class="group relative rounded-2xl px-6 py-4 text-sm font-semibold leading-6 text-zinc-900 sm:py-6"
           >
             <span class="absolute inset-0 rounded-2xl bg-zinc-50 transition group-hover:bg-zinc-100 sm:group-hover:scale-105">

--- a/lib/vyasa_web/live/mode_live/mediator.ex
+++ b/lib/vyasa_web/live/mode_live/mediator.ex
@@ -177,14 +177,25 @@ defmodule VyasaWeb.ModeLive.Mediator do
   def handle_event(
         "change_mode",
         %{
-          "current_mode" => current_mode,
+          "current_mode" => _current_mode,
           "target_mode" => target_mode
         } = _params,
-        socket
-      ) do
+        %Socket{
+          assigns: %{
+            url_params: %{path: path}
+          }
+        } = socket
+      )
+      when is_binary(path) and target_mode in @supported_modes do
+    target_path =
+      path
+      |> String.split("/")
+      |> List.replace_at(1, target_mode)
+      |> Enum.join("/")
+
     {:noreply,
      socket
-     |> change_mode(current_mode, target_mode)}
+     |> push_patch(to: target_path)}
   end
 
   @impl true

--- a/lib/vyasa_web/router.ex
+++ b/lib/vyasa_web/router.ex
@@ -26,14 +26,12 @@ defmodule VyasaWeb.Router do
       on_mount: [{VyasaWeb.Session, :sangh}, {VyasaWeb.Hook.UserAgent, :default}] do
       # NOTE: SLUG PATTERN:
       # /<mode>/<binding-info-slug>/<final_identifying_slug>?=<url-encoded-params>
-      # TODO: to standardise, should rename "explore" -> "read"
-      # TODO: @ks0m1c @rtshkmr the actions need to be udpated so that mediator can pipe things based on mode
-      live "/explore/", ModeLive.Mediator, :show_sources
-      live "/explore/:source_title/", ModeLive.Mediator, :show_chapters
-      live "/explore/:source_title/:chap_no", ModeLive.Mediator, :show_verses
-      # live "/discuss/", ModeLive.Mediator, :show_sources
-      # live "/discuss/:source_title/", ModeLive.Mediator, :show_chapters
-      # live "/discuss/:source_title/:chap_no", ModeLive.Mediator, :show_verses
+      live "/read/", ModeLive.Mediator, :show_sources
+      live "/read/:source_title/", ModeLive.Mediator, :show_chapters
+      live "/read/:source_title/:chap_no", ModeLive.Mediator, :show_verses
+      live "/discuss/", ModeLive.Mediator, :index
+      live "/discuss/:source_title/", ModeLive.Mediator, :discuss_source
+      live "/discuss/:source_title/:chap_no", ModeLive.Mediator, :discuss_chapter
     end
 
     live_admin "/admin" do


### PR DESCRIPTION

This adds mode-specific routing, it's non-breaking right now. 

Discuss routes currently get defaulted to :index, will wire that up properly when handling the discuss cruds. 



## Testing Instructions:
1. mode changes should be patches (so playback state will be preserved)
2. new routes should be rendered without breaking (see router) 


